### PR TITLE
ci: disable KICS workflow - TeamPCP supply chain attack (2026-03-23)

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,33 +1,34 @@
-name: KICS Scan
-
-on:
-  push:
-    branches:
-      - main
-  pull_request:
-  workflow_dispatch:
-
-jobs:
-  kics:
-    name: Kics Scan
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      pull-requests: write
-    steps:
-      - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
-      - name: run kics Scan
-        uses: checkmarx/kics-github-action@00def9108246ec656aea725db2167522d26a99d2 # v2.1.19
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          path: "."
-          ignore_on_exit: results
-          enable_annotations: true
-          enable_comments: true
-          enable_jobs_summary: true
-          comments_with_queries: true
-          output_path: ./results
-          output_formats: json
-      - name: Display results
-        run: |
-          cat ./results/results.json
+# Disabled - TeamPCP supply chain attack on checkmarx/kics-github-action (2026-03-23)
+# name: KICS Scan
+#
+# on:
+#   push:
+#     branches:
+#       - main
+#   pull_request:
+#   workflow_dispatch:
+#
+# jobs:
+#   kics:
+#     name: Kics Scan
+#     runs-on: ubuntu-latest
+#     permissions:
+#       contents: read
+#       pull-requests: write
+#     steps:
+#       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+#       - name: run kics Scan
+#         uses: checkmarx/kics-github-action@00def9108246ec656aea725db2167522d26a99d2 # v2.1.19
+#         with:
+#           token: ${{ secrets.GITHUB_TOKEN }}
+#           path: "."
+#           ignore_on_exit: results
+#           enable_annotations: true
+#           enable_comments: true
+#           enable_jobs_summary: true
+#           comments_with_queries: true
+#           output_path: ./results
+#           output_formats: json
+#       - name: Display results
+#         run: |
+#           cat ./results/results.json


### PR DESCRIPTION
## Context

Supply chain attack **TeamPCP** on `checkmarx/kics-github-action` detected today (2026-03-23).
35 tags compromised between 12:58–16:50 UTC (v1→v1.7.0, v2→v2.1.20).
Malware steals `GITHUB_TOKEN` and exfiltrates to `checkmarx.zone`.

## Changes

- KICS workflow fully commented out pending safe SHA verification from Checkmarx

## Next steps

Re-enable once Checkmarx confirms a safe SHA and publishes a post-mortem.