### PR TITLE
chore: update github-actions SHA to test trowaflo/github-actions#42

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   lint:
-    uses: trowaflo/github-actions/.github/workflows/lint.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.1.0
+    uses: trowaflo/github-actions/.github/workflows/lint.yml@d51fc48891c455f85a902e3d23f8ac7a52ef273e # v1.1.0
     permissions:
       contents: read
       security-events: write   # SARIF uploads (actionlint)
@@ -18,7 +18,7 @@ jobs:
       enable_json_lint: true
 
   security:
-    uses: trowaflo/github-actions/.github/workflows/security.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.1.0
+    uses: trowaflo/github-actions/.github/workflows/security.yml@d51fc48891c455f85a902e3d23f8ac7a52ef273e # v1.1.0
     permissions:
       contents: read
       pull-requests: write     # gitleaks annotations, dependency-review, KICS comments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,19 +7,21 @@ on:
 permissions: read-all
 
 jobs:
-  quality:
-    uses: trowaflo/github-actions/.github/workflows/quality.yml@9d58d4647688c45c876ab4c1072e0d1573b0939c # v4.1.0
+  lint:
+    uses: trowaflo/github-actions/.github/workflows/lint.yml@2464b3e45fadaadabfe7df91014d01490a0ad9c9 # v1.0.0
     permissions:
       contents: read
-      pull-requests: write
-      security-events: write
-      actions: read
+      security-events: write   # SARIF uploads (actionlint)
     with:
-      enable_gitleaks: true
-      enable_checkov: true
-      enable_actionlint: true
-      enable_trivy: true
-      enable_dependency_review: true
+      enable_markdown_lint: true
       enable_yamllint: true
       enable_json_lint: true
-      enable_markdown_lint: true
+
+  security:
+    uses: trowaflo/github-actions/.github/workflows/security.yml@2464b3e45fadaadabfe7df91014d01490a0ad9c9 # v1.0.0
+    permissions:
+      contents: read
+      pull-requests: write     # gitleaks annotations, dependency-review, KICS comments
+      security-events: write   # SARIF uploads (kics, trivy, checkov)
+    with:
+      enable_dependency_review: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   lint:
-    uses: trowaflo/github-actions/.github/workflows/lint.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.0.0
+    uses: trowaflo/github-actions/.github/workflows/lint.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.1.0
     permissions:
       contents: read
       security-events: write   # SARIF uploads (actionlint)
@@ -18,7 +18,7 @@ jobs:
       enable_json_lint: true
 
   security:
-    uses: trowaflo/github-actions/.github/workflows/security.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.0.0
+    uses: trowaflo/github-actions/.github/workflows/security.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.1.0
     permissions:
       contents: read
       pull-requests: write     # gitleaks annotations, dependency-review, KICS comments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   lint:
-    uses: trowaflo/github-actions/.github/workflows/lint.yml@2464b3e45fadaadabfe7df91014d01490a0ad9c9 # v1.0.0
+    uses: trowaflo/github-actions/.github/workflows/lint.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.0.0
     permissions:
       contents: read
       security-events: write   # SARIF uploads (actionlint)
@@ -18,7 +18,7 @@ jobs:
       enable_json_lint: true
 
   security:
-    uses: trowaflo/github-actions/.github/workflows/security.yml@2464b3e45fadaadabfe7df91014d01490a0ad9c9 # v1.0.0
+    uses: trowaflo/github-actions/.github/workflows/security.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.0.0
     permissions:
       contents: read
       pull-requests: write     # gitleaks annotations, dependency-review, KICS comments

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   quality:
-    uses: trowaflo/github-actions/.github/workflows/quality.yml@3f7ba998a4d4e9dcc3ff124be1333f3d84395852 # v4.1.0
+    uses: trowaflo/github-actions/.github/workflows/quality.yml@9d58d4647688c45c876ab4c1072e0d1573b0939c # v4.1.0
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   helm-ci:
-    uses: trowaflo/github-actions/.github/workflows/ci-helm.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.1.0
+    uses: trowaflo/github-actions/.github/workflows/ci-helm.yml@d51fc48891c455f85a902e3d23f8ac7a52ef273e # v1.1.0
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   helm:
-    uses: trowaflo/github-actions/.github/workflows/helm-ci.yml@3f7ba998a4d4e9dcc3ff124be1333f3d84395852 # v4.1.0
+    uses: trowaflo/github-actions/.github/workflows/helm-ci.yml@9d58d4647688c45c876ab4c1072e0d1573b0939c # v4.1.0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   helm-ci:
-    uses: trowaflo/github-actions/.github/workflows/ci-helm.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.0.0
+    uses: trowaflo/github-actions/.github/workflows/ci-helm.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.1.0
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   helm-ci:
-    uses: trowaflo/github-actions/.github/workflows/ci-helm.yml@2464b3e45fadaadabfe7df91014d01490a0ad9c9 # v1.0.0
+    uses: trowaflo/github-actions/.github/workflows/ci-helm.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.0.0
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -14,37 +14,30 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  helm:
-    uses: trowaflo/github-actions/.github/workflows/helm-ci.yml@9d58d4647688c45c876ab4c1072e0d1573b0939c # v4.1.0
+  helm-ci:
+    uses: trowaflo/github-actions/.github/workflows/ci-helm.yml@2464b3e45fadaadabfe7df91014d01490a0ad9c9 # v1.0.0
     permissions:
       contents: write
-      pull-requests: write
       checks: write
+      pull-requests: write
     with:
+      charts_dir: "charts"
+      enable_bump: true
+      enable_docs: true
+      enable_docs_check: true
+      enable_lint: true
+      enable_pr_charts: true
+      enable_unittest: true
       harden_runner_allowed_endpoints: >-
-        github.com:443
-        api.github.com:443
-        objects.githubusercontent.com:443
-        release-assets.githubusercontent.com:443
         registry.npmjs.org:443
-        get.helm.sh:443
         tuf-repo-cdn.sigstore.dev:443
         rekor.sigstore.dev:443
         fulcio.sigstore.dev:443
         pypi.org:443
         files.pythonhosted.org:443
-        ghcr.io:443
         pkg-containers.githubusercontent.com:443
-        quay.io:443
         cdn01.quay.io:443
-        cr.kgateway.dev:443
         aureq.github.io:443
         grafana.github.io:443
         prometheus-community.github.io:443
         trowaflo.github.io:443
-      enable_lint: true
-      enable_unittest: true
-      enable_docs: true
-      enable_docs_check: true
-      enable_bump: true
-      enable_pr_charts: true

--- a/.github/workflows/helm-pr-cleanup.yml
+++ b/.github/workflows/helm-pr-cleanup.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   cleanup:
-    uses: trowaflo/github-actions/.github/workflows/ci-helm-cleanup.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.0.0
+    uses: trowaflo/github-actions/.github/workflows/ci-helm-cleanup.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.1.0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/helm-pr-cleanup.yml
+++ b/.github/workflows/helm-pr-cleanup.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   cleanup:
-    uses: trowaflo/github-actions/.github/workflows/ci-helm-cleanup.yml@2464b3e45fadaadabfe7df91014d01490a0ad9c9 # v1.0.0
+    uses: trowaflo/github-actions/.github/workflows/ci-helm-cleanup.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.0.0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/helm-pr-cleanup.yml
+++ b/.github/workflows/helm-pr-cleanup.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   cleanup:
-    uses: trowaflo/github-actions/.github/workflows/helm-pr-cleanup.yml@9d58d4647688c45c876ab4c1072e0d1573b0939c # v4.1.0
+    uses: trowaflo/github-actions/.github/workflows/ci-helm-cleanup.yml@2464b3e45fadaadabfe7df91014d01490a0ad9c9 # v1.0.0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/helm-pr-cleanup.yml
+++ b/.github/workflows/helm-pr-cleanup.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   cleanup:
-    uses: trowaflo/github-actions/.github/workflows/ci-helm-cleanup.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.1.0
+    uses: trowaflo/github-actions/.github/workflows/ci-helm-cleanup.yml@d51fc48891c455f85a902e3d23f8ac7a52ef273e # v1.1.0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/helm-pr-cleanup.yml
+++ b/.github/workflows/helm-pr-cleanup.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   cleanup:
-    uses: trowaflo/github-actions/.github/workflows/helm-pr-cleanup.yml@3f7ba998a4d4e9dcc3ff124be1333f3d84395852 # v4.1.0
+    uses: trowaflo/github-actions/.github/workflows/helm-pr-cleanup.yml@9d58d4647688c45c876ab4c1072e0d1573b0939c # v4.1.0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   release:
-    uses: trowaflo/github-actions/.github/workflows/release-helm.yml@2464b3e45fadaadabfe7df91014d01490a0ad9c9 # v1.0.0
+    uses: trowaflo/github-actions/.github/workflows/release-helm.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.0.0
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   release:
-    uses: trowaflo/github-actions/.github/workflows/release-helm.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.0.0
+    uses: trowaflo/github-actions/.github/workflows/release-helm.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.1.0
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -12,7 +12,7 @@ permissions: read-all
 
 jobs:
   release:
-    uses: trowaflo/github-actions/.github/workflows/release-helm.yml@16b746a93e387b41b394d2f0c6000d1f9e5d5a49 # v1.1.0
+    uses: trowaflo/github-actions/.github/workflows/release-helm.yml@d51fc48891c455f85a902e3d23f8ac7a52ef273e # v1.1.0
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -11,7 +11,7 @@ permissions: read-all
 
 jobs:
   release:
-    uses: trowaflo/github-actions/.github/workflows/helm-release.yml@3f7ba998a4d4e9dcc3ff124be1333f3d84395852 # v4.1.0
+    uses: trowaflo/github-actions/.github/workflows/helm-release.yml@9d58d4647688c45c876ab4c1072e0d1573b0939c # v4.1.0
     permissions:
       contents: write
       pages: write

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -1,6 +1,7 @@
 name: Helm Release
 
 on:
+  pull_request:
   push:
     branches:
       - main
@@ -11,16 +12,10 @@ permissions: read-all
 
 jobs:
   release:
-    uses: trowaflo/github-actions/.github/workflows/helm-release.yml@9d58d4647688c45c876ab4c1072e0d1573b0939c # v4.1.0
+    uses: trowaflo/github-actions/.github/workflows/release-helm.yml@2464b3e45fadaadabfe7df91014d01490a0ad9c9 # v1.0.0
     permissions:
       contents: write
       pages: write
-      id-token: write
     with:
-      harden_runner_allowed_endpoints: >-
-        github.com:443
-        api.github.com:443
-        objects.githubusercontent.com:443
-        release-assets.githubusercontent.com:443
       enable_release: true
       release_charts_dirs: "charts/library charts/apps"


### PR DESCRIPTION
## Summary

Test the changes from [trowaflo/github-actions#42](https://github.com/trowaflo/github-actions/pull/42) (PR dry-run guards + test release & renovate workflows).

### Changes
- Updated all 4 workflow files to use SHA `9d58d464` (head of `feat/dry-run-guards` branch):
  - `ci.yml`
  - `helm-ci.yml`
  - `helm-pr-cleanup.yml`
  - `helm-release.yml`

> ⚠️ Revert this SHA once github-actions#42 is merged and tagged.