### PR TITLE
feat(ci): enable OCI dual-publish on main releases (release-helm v2.1.0)

### DIFF
--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -12,10 +12,12 @@ permissions: read-all
 
 jobs:
   release:
-    uses: trowaflo/github-actions/.github/workflows/release-helm.yml@d51fc48891c455f85a902e3d23f8ac7a52ef273e # v1.1.0
+    uses: trowaflo/github-actions/.github/workflows/release-helm.yml@8358d28b9b77208a15f1fa3536c03baca0d21650 # v2.1.0
     permissions:
       contents: write
       pages: write
+      packages: write
     with:
       enable_release: true
+      enable_oci_release: true
       release_charts_dirs: "charts/library charts/apps"

--- a/charts/apps/persistent-volume/Chart.yaml
+++ b/charts/apps/persistent-volume/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: persistent-volume
-version: 0.1.1
+version: 0.2.0
 type: application
 description: |-
   Helm chart for declarative creation and management of Kubernetes PersistentVolumes (PV)

--- a/charts/apps/persistent-volume/Chart.yaml
+++ b/charts/apps/persistent-volume/Chart.yaml
@@ -1,4 +1,3 @@
-# Pilot: re-validate OCI dual-publish on stable v2.0.0 (after PR #55 merged)
 apiVersion: v2
 name: persistent-volume
 version: 0.1.1


### PR DESCRIPTION
## Summary

Bumps `helm-release.yml` to use `release-helm.yml@v2.1.0` (released today) and activates `enable_oci_release: true` so charts released on `main` are dual-published to GitHub Pages **and** GHCR OCI.

## Changes

- **`.github/workflows/helm-release.yml`**:
  - `uses: trowaflo/github-actions/.github/workflows/release-helm.yml@v2.1.0` (was `v1.1.0`)
  - `permissions: packages: write` added (required for `helm push` to GHCR)
  - `enable_oci_release: true` (new toggle introduced upstream in trowaflo/github-actions#57)
- **`charts/apps/persistent-volume/Chart.yaml`**: remove the stale pilot comment (`# Pilot: re-validate OCI dual-publish on stable v2.0.0`). This counts as a chart change, so helm-ci will patch-bump `persistent-volume` (`0.1.1 → 0.1.2`) and chart-releaser on `main` will produce a release — exercising the new OCI publish path end-to-end.

## How to validate after merge

Once on `main`, the release job logs should show `Publish first/second directory to OCI registry (GHCR)`. Then:

```bash
helm pull oci://ghcr.io/trowaflo/helm-charts/persistent-volume --version 0.1.2
```

Should succeed without auth (or with `gh auth token` if GHCR package is private).

## Test plan

- [x] `helm-release.yml` YAML parse OK
- [ ] CI green on PR (helm-ci as usual; helm-release does not run on PR event)
- [ ] After merge: `Helm Release` workflow on main shows "Publish ... to OCI registry" steps and they conclude `success`
- [ ] `helm pull oci://ghcr.io/trowaflo/helm-charts/persistent-volume:0.1.2` works
