### PR TITLE
fix(kgateway-routing): default X-Frame-Options to SAMEORIGIN

### DIFF
--- a/charts/apps/kgateway-routing/tests/security_headers_test.yaml
+++ b/charts/apps/kgateway-routing/tests/security_headers_test.yaml
@@ -26,7 +26,7 @@ tests:
           value: X-Frame-Options
       - equal:
           path: spec.rules[0].filters[0].responseHeaderModifier.set[1].value
-          value: DENY
+          value: SAMEORIGIN
       - contains:
           path: spec.rules[0].filters[0].responseHeaderModifier.remove
           content: Server

--- a/charts/apps/kgateway-routing/values.yaml
+++ b/charts/apps/kgateway-routing/values.yaml
@@ -217,8 +217,13 @@ defaultSecurityHeaders:
   set:
     - name: Strict-Transport-Security
       value: "max-age=63072000; includeSubDomains; preload"
+    # SAMEORIGIN (not DENY) so apps that embed their own sub-dashboards via
+    # iframes from the same origin still work — e.g. Home Assistant Hassio
+    # Ingress (`/api/hassio_ingress/<token>/`), Frigate, NodeRED, ESPHome.
+    # DENY blocks clickjacking from external sites the same way, but also
+    # breaks same-origin admin panels.
     - name: X-Frame-Options
-      value: "DENY"
+      value: "SAMEORIGIN"
     - name: X-Content-Type-Options
       value: "nosniff"
     - name: Referrer-Policy


### PR DESCRIPTION
## Summary
- Change defaultSecurityHeaders X-Frame-Options from `DENY` to `SAMEORIGIN`
- DENY breaks apps that embed sub-dashboards via same-origin iframes

## Why
Vécu sur Home Assistant : avec `securityHeaders: true` opt-in, les addons Hassio Ingress (`/api/hassio_ingress/<token>/...`) chargés en iframe par l'UI principale sont bloqués par le browser. Même problème attendu sur Frigate, NodeRED, ESPHome.

SAMEORIGIN bloque toujours le clickjacking depuis un site externe (le vrai vecteur d'attaque). Le seul gain de DENY est contre du clickjacking same-origin, scénario marginal qui implique déjà une XSS sur le site lui-même.