### PR TITLE
chore(kgateway-routing): bump version to 0.5.1

### DIFF
--- a/charts/apps/kgateway-routing/Chart.yaml
+++ b/charts/apps/kgateway-routing/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: kgateway-routing
-version: 0.5.0
+version: 0.5.1
 type: application
 description: |-
   Helm chart for managing Kubernetes Gateway API HTTPRoute and Backend resources.


### PR DESCRIPTION
## Summary
Manual bump `kgateway-routing` 0.5.0 → 0.5.1 pour publier la release.

## Why
PR #245 (`fix(kgateway-routing): default X-Frame-Options to SAMEORIGIN`) a été mergée trop vite : la job `helm-bump` du workflow Helm CI tente un checkout de \`github.head_ref\` après le merge, mais la branche venait d'être auto-supprimée. Résultat : Chart.yaml resté à 0.5.0 sur main → \`chart-releaser\` a skip la release car 0.5.0 existait déjà.

Cette PR fait manuellement ce que le bot aurait fait. Une fois mergée, Helm Release publiera \`kgateway-routing-0.5.1\` sur GH Pages + OCI.

## To avoid in the future
Attendre que **toutes** les checks (notamment "Helm CI") soient ✅ — pas juste "Helm Release" — avant de merger une PR sur ce repo. Le job \`helm-bump\` doit avoir poussé son commit "ci: bump chart versions [skip ci]" sur la branche avant que le squash & merge la supprime.

## Test plan
- [ ] Attendre que tous les checks de cette PR soient verts (incl. \`helm-bump\` qui pourrait re-bumper à 0.5.2 ou no-op)
- [ ] Merger
- [ ] Vérifier qu'une release \`kgateway-routing-0.5.1\` (ou .2) apparaît
- [ ] Bumper \`infra/argo/global-values.yaml\` côté argocd avec la version effectivement publiée