### PR TITLE
chore(deps): bump trowaflo/github-actions to v3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   lint:
-    uses: trowaflo/github-actions/.github/workflows/lint.yml@8358d28b9b77208a15f1fa3536c03baca0d21650 # v2.1.0
+    uses: trowaflo/github-actions/.github/workflows/lint.yml@745d89e5792c3f9dd0c62e33a1065afd2eadc7a7 # v3.0.0
     permissions:
       contents: read
       security-events: write   # SARIF uploads (actionlint)
@@ -19,7 +19,7 @@ jobs:
       enable_json_lint: true
 
   security:
-    uses: trowaflo/github-actions/.github/workflows/security.yml@8358d28b9b77208a15f1fa3536c03baca0d21650 # v2.1.0
+    uses: trowaflo/github-actions/.github/workflows/security.yml@745d89e5792c3f9dd0c62e33a1065afd2eadc7a7 # v3.0.0
     permissions:
       contents: read
       pull-requests: write     # gitleaks annotations, dependency-review, KICS comments

--- a/.github/workflows/helm-ci.yml
+++ b/.github/workflows/helm-ci.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   helm-ci:
-    uses: trowaflo/github-actions/.github/workflows/ci-helm.yml@8358d28b9b77208a15f1fa3536c03baca0d21650 # v2.1.0
+    uses: trowaflo/github-actions/.github/workflows/ci-helm.yml@745d89e5792c3f9dd0c62e33a1065afd2eadc7a7 # v3.0.0
     permissions:
       contents: write
       checks: write

--- a/.github/workflows/helm-pr-cleanup.yml
+++ b/.github/workflows/helm-pr-cleanup.yml
@@ -12,7 +12,7 @@ concurrency:
 
 jobs:
   cleanup:
-    uses: trowaflo/github-actions/.github/workflows/ci-helm-cleanup.yml@8358d28b9b77208a15f1fa3536c03baca0d21650 # v2.1.0
+    uses: trowaflo/github-actions/.github/workflows/ci-helm-cleanup.yml@745d89e5792c3f9dd0c62e33a1065afd2eadc7a7 # v3.0.0
     permissions:
       contents: write
       packages: write

--- a/.github/workflows/helm-release.yml
+++ b/.github/workflows/helm-release.yml
@@ -17,7 +17,7 @@ permissions: read-all
 
 jobs:
   release:
-    uses: trowaflo/github-actions/.github/workflows/release-helm.yml@8358d28b9b77208a15f1fa3536c03baca0d21650 # v2.1.0
+    uses: trowaflo/github-actions/.github/workflows/release-helm.yml@745d89e5792c3f9dd0c62e33a1065afd2eadc7a7 # v3.0.0
     permissions:
       contents: write
       pages: write


### PR DESCRIPTION
## Ce que ça change

`harden_runner_egress_policy` passe de `audit` à `block` par défaut, breaking change de v3.0.0. Legress hors allowlist intégrée est désormais **coupé**, plus seulement observé.

Parade au vecteur TeamPCP : linfostealer qui a tourné dans 13 repos de ce compte le 2026-03-23 exfiltrait par un POST HTTPS vers un domaine tiers. Épingler laction par SHA narrête pas ça, elle construit son Dockerfile au runtime depuis un tag dimage mutable.

## Prouvé avant de dérouler

Canari `terraform-authentik`, le plus large des cinq consommateurs. `IaC Scan (KICS)`, `IaC Scan (Checkov)` et `IaC Scan (Trivy)` tous verts sous `block` le 2026-08-14.

Contrats de permissions audités contre les workflows de v3.0.0 : les appelants de ce repo couvrent déjà ce que les workflows appelés exigent.

## Si ça casse

Un blocage degress légitime se lit dans les logs harden-runner et se corrige via `harden_runner_allowed_endpoints`. Repasser `harden_runner_egress_policy: audit` restaure lancien comportement, mais cest un repli, pas une solution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tnNzt8kSuX88cRnvNhLL8